### PR TITLE
Fixes #40: Load project by URL

### DIFF
--- a/tm_cm.js
+++ b/tm_cm.js
@@ -1852,11 +1852,7 @@ function getParameterByName(name, url = window.location.href) {
 }
 
 var projectUrl = getParameterByName('project')
-let str = ""
-try {
-  str = localStorage.getItem("loadedProjectUrl");
-} catch (error) {
-}
+let str = localStorage.getItem("loadedProjectUrl");
 if (projectUrl != "" && projectUrl != str) {
   localStorage.setItem("loadedProjectUrl", projectUrl);
   resetProject(false);

--- a/tm_cm.js
+++ b/tm_cm.js
@@ -1852,7 +1852,13 @@ function getParameterByName(name, url = window.location.href) {
 }
 
 var projectUrl = getParameterByName('project')
-if (projectUrl != "") {
+let str = ""
+try {
+  str = localStorage.getItem("loadedProjectUrl");
+} catch (error) {
+}
+if (projectUrl != "" && projectUrl != str) {
+  localStorage.setItem("loadedProjectUrl", projectUrl);
   resetProject(false);
   loadInitialProject(projectUrl)
 }

--- a/tm_cm.js
+++ b/tm_cm.js
@@ -1146,7 +1146,7 @@ function addUserFile(th) {
   th.value = "";
 }
 
-function getImageFormUrl(url, callback) {
+function getImageFromUrl(url, callback) {
   var img = new Image();
   img.setAttribute('crossOrigin', 'anonymous');
   img.onload = function (a) {
@@ -1183,7 +1183,7 @@ function getImageFormUrl(url, callback) {
 function loadInitialProject(url) {
   projectLoad = true;
   try {
-      getImageFormUrl(url, function (blobImage) {
+      getImageFromUrl(url, function (blobImage) {
         const reader = new FileReader();
         reader.addEventListener('load', function() {
           let newI = new Image();

--- a/tm_cm.js
+++ b/tm_cm.js
@@ -1146,6 +1146,59 @@ function addUserFile(th) {
   th.value = "";
 }
 
+function getImageFormUrl(url, callback) {
+  var img = new Image();
+  img.setAttribute('crossOrigin', 'anonymous');
+  img.onload = function (a) {
+  var canvas = document.createElement("canvas");
+  canvas.width = this.width;
+  canvas.height = this.height;
+  var ctx = canvas.getContext("2d");
+  ctx.drawImage(this, 0, 0);
+
+  var dataURI = canvas.toDataURL("image/jpg");
+
+  // convert base64/URLEncoded data component to raw binary data held in a string
+  var byteString;
+  if (dataURI.split(',')[0].indexOf('base64') >= 0)
+    byteString = atob(dataURI.split(',')[1]);
+  else
+    byteString = unescape(dataURI.split(',')[1]);
+
+  // separate out the mime component
+  var mimeString = dataURI.split(',')[0].split(':')[1].split(';')[0];
+
+  // write the bytes of the string to a typed array
+  var ia = new Uint8Array(byteString.length);
+  for (var i = 0; i < byteString.length; i++) {
+    ia[i] = byteString.charCodeAt(i);
+  }
+
+  return callback(new Blob([ia], { type: mimeString }));
+  }
+
+  img.src = url;
+}
+
+function loadInitialProject(url) {
+  projectLoad = true;
+  try {
+      getImageFormUrl(url, function (blobImage) {
+        const reader = new FileReader();
+        reader.addEventListener('load', function() {
+          let newI = new Image();
+          newI.onload = userImageLoaded;
+          newI.src = reader.result;
+          newI.crossOrigin = "Anonymous";
+        });
+        reader.readAsDataURL(blobImage);
+      });
+  } catch (error) {
+    projectLoad = false;
+    window.alert("Something went wrong loading initial project." + error)
+  }
+}
+
 var oLoadedProject;
 
 function userImageLoaded() {
@@ -1789,4 +1842,20 @@ function sortable(section, onUpdate){
 }
      
 
-resetProject(true);
+function getParameterByName(name, url = window.location.href) {
+    name = name.replace(/[\[\]]/g, '\\$&');
+    var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, ' '));
+}
+
+var projectUrl = getParameterByName('project')
+if (projectUrl != "") {
+  resetProject(false);
+  loadInitialProject(projectUrl)
+}
+else {
+  resetProject(true);
+}


### PR DESCRIPTION
Add a 'project' query parameter to allow Card Maker to read from an online project data url.

This works pretty well, but it changes reload behavior a bit. In the presence of a `?project=` url, a reload will erase all changes and reload a fresh copy of the project from the specified URL. When there is no `?project` query parameter, then an attempt is made to restore in-project work, maintaining current behavior. (c.f. #2)

To test, try adding `?project=https://raw.githubusercontent.com/g1a/tm_fanmade/main/card/corporation/OceanicCo/default/project-data.png` when loading tm_cardmaker.