### PR TITLE
Rename 'others' background to 'any player' / red border.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This part will assume you want to make a normal project. Corporation or Prelude 
 - 'Base' is just the size of your card, in pixels and the background color.
 - 'Green Card' is almost everything else you see (sans text). Generally you won't adjust this layer.
 - 'No Requirement' is that little graphic near the card cost. In this case the card has no requirements.
+- Some layer types have a checkbox labeled 'Any player' red boarder. Check this if you want to put a red border around the tag, resource or tile icon, indicating that the card effect can target any player.
 - Let's change the card to a card with a requirement.
 - Delete the 'No Requirement' layer by clicking the 'X' next to its name.
 - On the left menu, click 'Add Block' then 'Requirements' then 'Min Requirement (small)'. Wow that is NOT small!

--- a/tm_cardmaker.html
+++ b/tm_cardmaker.html
@@ -192,7 +192,7 @@ body,h1,h2,h3,h4,h5,h6,.w3-wide {font-family: "Montserrat", sans-serif;}
       <span style="float: right;">sheight:<input id="inputsheight" type="number" min="1" onchange="updateValue(this)"></span><br>
     </div>
     <div id="otherbg" class="w3-hide">
-      <span>'Others' background:<input id="inputobg" type="checkbox" onchange="updateValue(this)"></span><br>
+      <span>'Any player' red border:<input id="inputobg" type="checkbox" onchange="updateValue(this)"></span><br>
     </div>
     <div id="alltext" class="w3-hide">
       <span style="float: right;"><textarea id="inputdata" cols="17" onchange="updateValue(this)"></textarea></span><br>

--- a/tm_cm.js
+++ b/tm_cm.js
@@ -599,7 +599,7 @@ function drawProject() {
           c.width = layer.width;
         }
         // layer = {type:"block", obj:{}, x:0, y:0, width:0, height:0, params:"allimages"};
-        if (layer.obg) { // draw others background?
+        if (layer.obg) { // draw the 'any player' red border, aka 'others' background?
           let brdr = 3;
           if (!otherBgList[blockList[layer.iNum].otherbg]) {
             for (let j=0; j < blockList.length; j++) {


### PR DESCRIPTION
The Terraforming Mars rules refers to the "others" background as the "any player" border or the red border. This PR updates the text used in controls to match the rules, so that it is more clear what this checkbox is for.