### PR TITLE
Change the redirect-on-load to stay on the same page.

### DIFF
--- a/tm_cm.js
+++ b/tm_cm.js
@@ -1856,7 +1856,9 @@ var projectUrl = getParameterByName('project')
 let str = localStorage.getItem("loadedProjectUrl");
 if (projectUrl && projectUrl != "") {
   localStorage.setItem("loadedProjectUrl", projectUrl);
-  window.location.assign("https://sliceofbread.neocities.org/tm/tm_cardmaker.html");
+  // Redirect without the query parameters now that they are stored in local
+  // storage, so that they do not cause problems e.g. on reload or "new".
+  window.location.assign(location.protocol + '//' + location.host + location.pathname);
 } else if (str && str != "") {
   resetProject(false);
   loadInitialProject(str)


### PR DESCRIPTION
89751b0 always redirects to the official tm_cardmaker location, which makes it more difficult to do local development.

This PR ensures that the redirect removes the query parameters without changing the base URL, so that you will stay on the version of tm_cardmaker that you were originally using, rather than reverting back to the published version.