### PR TITLE
Move layers via mouse and arrow keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,25 +20,50 @@ Cheers!"
 
 ## How to Use
 
-This part will assume you want to make a normal project. Corporation or Prelude cards are similar.
-- Click 'File'
-- Click 'New from Template'
-- Click one of the templates that appears. For this example let's choose 'Green Card'
-- On the right (possibly bottom if you have a small screen) you will see the list of layers. Let's set the cost of the card by first selecting that layer. To start, it is labelled  'Text:Cost'. Click that.
-- That opens up all the information for the layer. Where it is positioned, the font, etc. Change the text, which is in the box jest below 'height'. It currently says 'Cost'. Change it to a number. To see the change, you need to 'tab' or click outside this box. If you felt like the number wasn't in the right spot, you can adjust the 'x' and 'y' to move it. If you want the font to be bigger or smaller, adjust the 'height'. You can also change the font/color. Click 'Text:Cost' when you're done (note you can change the layer name from 'Text:Cost' to anything else that you prefer.
-- The above holds for all the text layers. Additionally, if you have longer text, you can use 'width' to set the maximum width a line can be (in pixels) and you can use 'V space' to adjust the line-to-line spacing when the program splits your text across multiple lines. There's also a 'Justify' selection if you want your text to be centered, aligned on the left or right.
-- Other than text, there are a few other things already in your card.
-- 'Base' is just the size of your card, in pixels and the background color.
+TM_Cardmaker provides **templates**, **presets** and graphic assets called **blocks** to help build attractive card that match the look and feel of the original game.
+
+To begin, click on **File** > **New from Template**, and select an appropriate starting template for the card that you wish to design. The available templates include:
+
+- Corporation
+- Prelude card
+- Green project card (three layouts)
+- Blue project card (three layouts)
+- Red event card (two layouts)
+
+For this example, we'll choose 'Green Card'. This will create layers with the elements of the most common type of project card. On the right (possibly bottom if you have a small screen) you will see the list of layers. Let's set the cost of the card by first selecting that layer. To start, it is labelled  'Text:Cost'. Click that.
+
+Clicking on a layer opens up the layer information pane, which contains all of the information needed to render the layer (postion, font color, etc). Change the text, which is in the box jest below 'height'. It currently says 'Cost'. Change it to a number. To see the change, you need to 'tab' or click outside this box.
+
+If you felt like the number wasn't in the right spot, you can click on it on the rendered card, and drag it to the right spot. You can make fine adjustments by using the keyboard shortcuts:
+
+- The arrow keys will move the object one pixel
+- Shift + arrow keys move 1/12" at a time
+- Alt + up and down arrows will make the text size larger or smaller
+- Alt + left and right arrows will change the width of the text bounding box, which controls where word-wrapping happens.
+
+If you know exactly where you want the object to go, you can also type in its X and Y coordinates in the layer information pane. The 'height' controls the size of the text, and the 'width' is the aforementioned word-wrapping boundary. There is also a 'V space' setting that controls the line-to--line spacing. There's also a 'Justify' selection if you want your text to be centered, aligned on the left or right. Click on the layer name to apply your changes and re-render the object. Note that you can change the layer names to anything that you prefer.
+
+Other than text, there are a few other things already in your card.
+
+- 'Base' is just the size of your card, in pixels, and the background color.
 - 'Green Card' is almost everything else you see (sans text). Generally you won't adjust this layer.
 - 'No Requirement' is that little graphic near the card cost. In this case the card has no requirements.
-- Let's change the card to a card with a requirement.
+
+To demonstrate how to place new blocks and use presets, we'll change the card to a card with a requirement.
+
 - Delete the 'No Requirement' layer by clicking the 'X' next to its name.
 - On the left menu, click 'Add Block' then 'Requirements' then 'Min Requirement (small)'. Wow that is NOT small!
 - On the right, the layer has been added 'Min Requirement (sma'. Click it. Under 'Presets' choose the obvious 'Min Small'. Things should look much more normal. There are presets for almost anything you add. Some are more useful than others
 - Let's require an Ocean tile. On the left click 'Tiles' then 'Ocean'. On the right, click the new layer 'Ocean'. There is one preset, 'Standard'. Hmm, that is not very useful.
 - Change 'X' to 214 and 'y' to 87. Change 'width' to 67 (and watch height will change automatically). Mostly you will leave the 'Lock aspect ratio' box checked but if you want to change height and width independently, just uncheck it.
 
+Blocks can also be moved around with the mouse and arrow keys, just like text layers. Resizing blocks is a little different, though.
+
+- Alt + left and right arrow keys resize the selected object, maintaining anchor at upper-left
+- Alt + up and down arrow keys resize the selected object, maintaining anchor at the center of the object
+
 A couple other things to highlight:
+
 - If you want to use an image from the Web (with permission of course), that's under 'Add Block' -> 'User Images' -> 'Load Web Image'.
 - If you want to use an image from your computer, it's the same as above but 'Load Local Image'
 - You might want the above (or some other) layer to look like it's in the background. Drag the layer name to where you want it. The layers are draw, in order, from the top of the list to the bottom. 'Base' is always the first layer.

--- a/tm_cm.js
+++ b/tm_cm.js
@@ -1888,18 +1888,26 @@ elem.addEventListener("mousedown", dragStart, false);
 elem.addEventListener("mouseup", dragEnd, false);
 elem.addEventListener("mousemove", drag, false);
 
+function getMousePos(event) {
+    let c = document.getElementById("cmcanvas");
+    var rect = c.getBoundingClientRect();
+    return {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top
+    };
+}
+
 function dragStart(event) {
-    var x = (event.clientX - elemLeft),
-        y = (event.clientY - elemTop);
+    var mouse = getMousePos(event)
 
     // Collision detection between clicked offset and element.
     let layerDivs = document.getElementsByClassName("divRec");
     for (let i=layerDivs.length - 1; i >= 0; i--) {
       let layer = aLayers[layerDivs[i].id];
-      if (clickIsWithinLayer(layer, x, y)) {
+      if (clickIsWithinLayer(layer, mouse.x, mouse.y)) {
         layerToDrag = layer
-        dragOffsetX = layer.x - x
-        dragOffsetY = layer.y - y
+        dragOffsetX = layer.x - mouse.x
+        dragOffsetY = layer.y - mouse.y
         return
       }
     }
@@ -1964,8 +1972,9 @@ function dragEnd(event) {
 }
 
 function drag(event) {
-  var x = event.clientX - elemLeft + dragOffsetX,
-      y = event.clientY - elemTop + dragOffsetY;
+  var mouse = getMousePos(event)
+  var x = mouse.x + dragOffsetX,
+      y = mouse.y + dragOffsetY;
 
   if (layerToDrag != null) {
       layerToDrag.x = x

--- a/tm_cm.js
+++ b/tm_cm.js
@@ -1872,3 +1872,51 @@ if (projectUrl && projectUrl != "") {
 } else {
   resetProject(true);
 }
+
+var elem = document.getElementById('cmcanvas'),
+    elemLeft = elem.offsetLeft + elem.clientLeft,
+    elemTop = elem.offsetTop + elem.clientTop,
+    context = elem.getContext('2d')
+
+var layerToDrag
+var dragOffsetX
+var dragOffsetY
+
+// Add event listener for `drag` events.
+elem.addEventListener("mousedown", dragStart, false);
+elem.addEventListener("mouseup", dragEnd, false);
+elem.addEventListener("mousemove", drag, false);
+
+function dragStart(event) {
+    var x = event.clientX - elemLeft,
+        y = event.clientY - elemTop;
+
+    // Collision detection between clicked offset and element.
+    let layerDivs = document.getElementsByClassName("divRec");
+    for (let i=layerDivs.length - 1; i >= 0; i--) {
+      let layer = aLayers[layerDivs[i].id];
+      console.log('look at a layer named ' + layer.name + ' of type ' + layer.type + ' at ' + layer.x + ',' + layer.y + ' with params ' + layer.params)
+      if (y > layer.y && y < layer.y + layer.height 
+          && x > layer.x && x < layer.x + layer.width) {
+        layerToDrag = layer
+        dragOffsetX = layer.x - x
+        dragOffsetY = layer.y - y
+        return
+      }
+    }
+}
+
+function dragEnd(event) {
+  layerToDrag = null
+}
+
+function drag(event) {
+  var x = event.clientX - elemLeft + dragOffsetX,
+      y = event.clientY - elemTop + dragOffsetY;
+
+  if (layerToDrag != null) {
+      layerToDrag.x = x
+      layerToDrag.y = y
+      drawProject();
+  }
+}

--- a/tm_cm.js
+++ b/tm_cm.js
@@ -2007,6 +2007,7 @@ function moveLayerWithKey(event) {
       keyFocusLayer.width = keyFocusLayer.width + delta.w
       keyFocusLayer.height = keyFocusLayer.height + delta.h
       drawProject();
+      event.preventDefault()
     }
   }
 }

--- a/tm_cm.js
+++ b/tm_cm.js
@@ -11,6 +11,11 @@ var fontList = {
   times: ""
 };
 
+var layerToDrag;
+var dragOffsetX;
+var dragOffsetY;
+var keyFocusLayer;
+
 var blockList = [
   {putUnder: "templates", text: "Green Card", src:"green_normal"},
   {putUnder: "templates", text: "Green Small Bottom", src:"green_small_bottom"},
@@ -1851,45 +1856,6 @@ function sortable(section, onUpdate){
      
   });
 }
-     
-
-function getParameterByName(name, url = window.location.href) {
-    name = name.replace(/[\[\]]/g, '\\$&');
-    var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
-        results = regex.exec(url);
-    if (!results) return null;
-    if (!results[2]) return '';
-    return decodeURIComponent(results[2].replace(/\+/g, ' '));
-}
-
-var projectUrl = getParameterByName('project')
-let str = localStorage.getItem("loadedProjectUrl");
-if (projectUrl && projectUrl != "") {
-  localStorage.setItem("loadedProjectUrl", projectUrl);
-  // Redirect without the query parameters now that they are stored in local
-  // storage, so that they do not cause problems e.g. on reload or "new".
-  window.location.assign(location.protocol + '//' + location.host + location.pathname);
-} else if (str && str != "") {
-  resetProject(false);
-  loadInitialProject(str)
-} else {
-  resetProject(true);
-}
-
-var elem = document.getElementById('cmcanvas'),
-    elemLeft = elem.offsetLeft + elem.clientLeft,
-    elemTop = elem.offsetTop + elem.clientTop,
-    context = elem.getContext('2d')
-
-var layerToDrag
-var dragOffsetX
-var dragOffsetY
-var keyFocusLayer
-
-// Add event listener for `drag` events.
-elem.addEventListener("mousedown", dragStart, false);
-elem.addEventListener("mouseup", dragEnd, false);
-elem.addEventListener("mousemove", drag, false);
 
 function getMousePos(event) {
     let c = document.getElementById("cmcanvas");
@@ -1901,19 +1867,19 @@ function getMousePos(event) {
 }
 
 function dragStart(event) {
-    var mouse = getMousePos(event)
+    var mouse = getMousePos(event);
 
     // Collision detection between clicked offset and element.
     let layerDivs = document.getElementsByClassName("divRec");
     for (let i=layerDivs.length - 1; i >= 0; i--) {
       let layer = aLayers[layerDivs[i].id];
       if (clickIsWithinLayer(layer, mouse.x, mouse.y)) {
-        selectLayer()
-        layerToDrag = layer
-        focusKeyInput(layer)
-        dragOffsetX = layer.x - mouse.x
-        dragOffsetY = layer.y - mouse.y
-        return
+        selectLayer();
+        layerToDrag = layer;
+        focusKeyInput(layer);
+        dragOffsetX = layer.x - mouse.x;
+        dragOffsetY = layer.y - mouse.y;
+        return;
       }
     }
 }
@@ -1925,23 +1891,23 @@ function clickIsWithinLayer(layer, x, y) {
   // Check to see if we are inside the text bounding box of a text layer
   // n.b. Text is rendered just above the bounding box (bug?).
   if (layer.type == 'text') {
-    return clickIsWithinText(layer, x - layer.x, (y - layer.y) + layer.height)
+    return clickIsWithinText(layer, x - layer.x, (y - layer.y) + layer.height);
   }
 
   // If the x,y is not inside the bounding box, then it's definitely a miss
   if (y < layer.y || y > layer.y + layer.height
           || x < layer.x || x > layer.x + layer.width) {
-    return false
+    return false;
   }
 
   // If the bounding box is the only info we have about the layer, then that's what we'll use.
-  return true
+  return true;
 }
 
 // This function is a copy of the text-wrapping algorithm in drawProject()
 function clickIsWithinText(layer, x, y) {
   if (y < 0) {
-    return false
+    return false;
   }
   text = layer.data
   let c = document.getElementById("cmcanvas");
@@ -1957,7 +1923,7 @@ function clickIsWithinText(layer, x, y) {
         o += " " + spl.shift();
       }
       cnt++;
-      lineWidth = ctx.measureText(o).width
+      lineWidth = ctx.measureText(o).width;
       if (y < ((layer.height + layer.lineSpace) * cnt)) {
         if (layer.justify == "center") {
           x = x + (lineWidth / 2);
@@ -1973,7 +1939,7 @@ function clickIsWithinText(layer, x, y) {
 }
 
 function dragEnd(event) {
-  layerToDrag = null
+  layerToDrag = null;
 }
 
 function drag(event) {
@@ -1982,19 +1948,19 @@ function drag(event) {
       y = mouse.y + dragOffsetY;
 
   if (layerToDrag != null) {
-      layerToDrag.x = x
-      layerToDrag.y = y
+      layerToDrag.x = x;
+      layerToDrag.y = y;
       drawProject();
   }
 }
 
 function focusKeyInput(layer) {
-  keyFocusLayer = layer
+  keyFocusLayer = layer;
   document.addEventListener("keydown", moveLayerWithKey, false);
 }
 
 function removeKeyInputFocus() {
-  keyFocusLayer = null
+  keyFocusLayer = null;
   document.removeEventListener("keydown", moveLayerWithKey, false);
 }
 
@@ -2014,7 +1980,7 @@ function moveLayerWithKey(event) {
         keyFocusLayer.height = newHeight;
       }
       drawProject();
-      event.preventDefault()
+      event.preventDefault();
     }
   }
 }
@@ -2054,8 +2020,8 @@ function getMoveDeltas(event, aspectRatio) {
       var centered = (delta.y != 0);
       delta.w = delta.x - (2 * delta.y);
       delta.h = delta.w * aspectRatio;
-      delta.x = 0
-      delta.y = 0
+      delta.x = 0;
+      delta.y = 0;
       if (centered) {
         delta.x = -delta.w / 2;
         delta.y = -delta.h / 2;
@@ -2063,4 +2029,36 @@ function getMoveDeltas(event, aspectRatio) {
     }
     return delta;
 }
+
+function getParameterByName(name, url = window.location.href) {
+    name = name.replace(/[\[\]]/g, '\\$&');
+    var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, ' '));
+}
+
+var projectUrl = getParameterByName('project')
+let str = localStorage.getItem("loadedProjectUrl");
+if (projectUrl && projectUrl != "") {
+  localStorage.setItem("loadedProjectUrl", projectUrl);
+  // Redirect without the query parameters now that they are stored in local
+  // storage, so that they do not cause problems e.g. on reload or "new".
+  window.location.assign(location.protocol + '//' + location.host + location.pathname);
+} else if (str && str != "") {
+  resetProject(false);
+  loadInitialProject(str)
+} else {
+  resetProject(true);
+}
+
+var elem = document.getElementById('cmcanvas'),
+    elemLeft = elem.offsetLeft + elem.clientLeft,
+    elemTop = elem.offsetTop + elem.clientTop;
+
+// Add event listener for `drag` events.
+elem.addEventListener("mousedown", dragStart, false);
+elem.addEventListener("mouseup", dragEnd, false);
+elem.addEventListener("mousemove", drag, false);
 

--- a/tm_cm.js
+++ b/tm_cm.js
@@ -1884,6 +1884,57 @@ function dragStart(event) {
     }
 }
 
+// Check to see if the given coordinates are within the specified layer
+//
+// Block objects are anchored at the upper left, and may contain
+// transparent areas:
+//
+//    O-----------+
+//    |     .     |
+//    |   .....   |
+//    | ......... |
+//    | ......... |
+//    | ......... |
+//    |   .....   |
+//    |     .     |
+//    +-----------+
+//
+// For these sorts of layers, we can first check to see whether the
+// point is within the bounding rectangle, and then check to see if
+// the pixel under the point is transparent or not.
+//
+// Text layers do not lie within their bounding box. The width
+// of the bounding box is used to determine where text should wrap,
+// and the height of the bounding box controls the font size. The
+// anchor is on the baseline of the text. Text layers therefore
+// look something like this:
+//
+// Left-justified:
+//
+//                     THIS IS SOME TEXT
+//                     O--------------------+
+//                     +--------------------+
+//
+// Centered:
+//
+//             THIS IS SOME TEXT
+//                     O--------------------+
+//                     +--------------------+
+//
+// Right-justified:
+//
+//    THIS IS SOME TEXT
+//                     O--------------------+
+//                     +--------------------+
+//
+// Multi-line text layers will vertically overlap with the
+// bounding box on the second line only, with the third and
+// subsequent lines lying below the bounding box. To do hit
+// testing on text, then, we replicate the word-wrapping
+// algorithm and calculate a bounding rectangle for each line
+// individually, checkin each one until a hit is found.
+//
+// For all other layer types, the bounding box is used as specified.
 function clickIsWithinLayer(layer, x, y) {
   let c = document.getElementById("cmcanvas");
   let ctx = c.getContext("2d");

--- a/tm_cm.js
+++ b/tm_cm.js
@@ -1900,8 +1900,31 @@ function clickIsWithinLayer(layer, x, y) {
     return false;
   }
 
-  // If the bounding box is the only info we have about the layer, then that's what we'll use.
+  // If the click hits a transparent area, then count it as a miss
+  if (clickIsWithinTransparentArea(layer, x - layer.x, y - layer.y)) {
+    return false;
+  }
+
+  // If the click hasn't been found to be outside the area, then it is inside.
   return true;
+}
+
+function clickIsWithinTransparentArea(layer, x, y) {
+  if ((layer.type != "block") || (!blockList[layer.iNum].obj.complete)) {
+    console.log(layer);
+    return false;
+  }
+
+  try {
+    var ctx = document.createElement("canvas").getContext("2d");
+    ctx.drawImage(blockList[layer.iNum].obj, 0, 0, layer.width, layer.height);
+    alpha = ctx.getImageData(x, y, 1, 1).data[3]; // [0]R [1]G [2]B [3]A
+
+    return alpha === 0;
+  } catch (error) {
+    // https://stackoverflow.com/questions/16217521/i-get-a-canvas-has-been-tainted-error-in-chrome-but-not-in-ff/16218015#16218015
+    return false;
+  }
 }
 
 // This function is a copy of the text-wrapping algorithm in drawProject()
@@ -1993,8 +2016,8 @@ function moveLayerWithKey(event) {
         keyFocusLayer.y = newY;
         keyFocusLayer.width = newWidth;
         keyFocusLayer.height = newHeight;
+        drawProject();
       }
-      drawProject();
       event.preventDefault();
     }
   }

--- a/tm_cm.js
+++ b/tm_cm.js
@@ -1908,6 +1908,7 @@ function dragStart(event) {
     for (let i=layerDivs.length - 1; i >= 0; i--) {
       let layer = aLayers[layerDivs[i].id];
       if (clickIsWithinLayer(layer, mouse.x, mouse.y)) {
+        selectLayer()
         layerToDrag = layer
         focusKeyInput(layer)
         dragOffsetX = layer.x - mouse.x

--- a/tm_cm.js
+++ b/tm_cm.js
@@ -2002,10 +2002,16 @@ function moveLayerWithKey(event) {
     aspectRatio = keyFocusLayer.height / keyFocusLayer.width;
     delta = getMoveDeltas(event, aspectRatio)
     if (delta.x || delta.y || delta.w || delta.h) {
-      keyFocusLayer.x = keyFocusLayer.x + delta.x
-      keyFocusLayer.y = keyFocusLayer.y + delta.y
-      keyFocusLayer.width = keyFocusLayer.width + delta.w
-      keyFocusLayer.height = keyFocusLayer.height + delta.h
+      newX = keyFocusLayer.x + delta.x;
+      newY = keyFocusLayer.y + delta.y;
+      newWidth = keyFocusLayer.width + delta.w;
+      newHeight = keyFocusLayer.height + delta.h;
+      if (((newWidth >= 8) && (newHeight >=8)) || (delta.w > 0)) {
+        keyFocusLayer.x = newX;
+        keyFocusLayer.y = newY;
+        keyFocusLayer.width = newWidth;
+        keyFocusLayer.height = newHeight;
+      }
       drawProject();
       event.preventDefault()
     }
@@ -2044,11 +2050,16 @@ function getMoveDeltas(event, aspectRatio) {
 
     // If alt is down, convert movement into resize
     if (event.altKey) {
+      var centered = (delta.y != 0);
       delta.w = delta.x - (2 * delta.y);
       delta.h = delta.w * aspectRatio;
-      delta.x = delta.w * (delta.y / 2);
-      delta.y = delta.h * (delta.y / 2);
+      delta.x = 0
+      delta.y = 0
+      if (centered) {
+        delta.x = -delta.w / 2;
+        delta.y = -delta.h / 2;
+      }
     }
-    return delta
+    return delta;
 }
 

--- a/tm_cm.js
+++ b/tm_cm.js
@@ -2019,10 +2019,10 @@ function getMoveDeltas(event, aspectRatio) {
       h: 0
     };
 
-    // One pixel if shift is up, 1/6" if shift is down
+    // One pixel if shift is up, 1/12" if shift is down
     magnitude = 1;
     if (event.shiftKey) {
-      magnitude = 50;
+      magnitude = 25;
     }
 
     // Set the directions based on the key

--- a/tm_cm.js
+++ b/tm_cm.js
@@ -1969,6 +1969,21 @@ function moveLayerWithKey(event) {
     aspectRatio = keyFocusLayer.height / keyFocusLayer.width;
     delta = getMoveDeltas(event, aspectRatio)
     if (delta.x || delta.y || delta.w || delta.h) {
+      if (keyFocusLayer.type == "text") {
+        if (event.altKey) {
+          delta.x = 0;
+          delta.y = 0;
+          if ((event.key == "ArrowUp") || (event.key == "ArrowDown")) {
+            // Do not adjust the width for alt up / down, only change the font size
+            delta.w = 0;
+            delta.h = 2 * Math.sign(delta.h);
+            delta.y = delta.h
+          } else {
+            // Do not adjust the height for alt left / right, only change the width (wrap point)
+            delta.h = 0;
+          }
+        }
+      }
       newX = keyFocusLayer.x + delta.x;
       newY = keyFocusLayer.y + delta.y;
       newWidth = keyFocusLayer.width + delta.w;


### PR DESCRIPTION
Checklist:
- [x] Close open layer fields group when a drag begins 
- ~Update the layer fields if they are open when the drag ends~
-  ~Maybe open the layer fields if they are not open~
- [x] Fix up clicking on text areas; seems that bounding box might not be quite right
- [x] Do hit checking based on the layer's bitmap, when available, rather than the bounding box
- [x] Fix drag calculations so that it works correctly when the canvas is scrolled
- [x] Add key event handler to move selected object with arrow keys
- [x] Stop browser scrolling when arrow key is used to move an object
- [x] Add some brief docs